### PR TITLE
Ajout de la gestion des temps vocaux et des badges associés

### DIFF
--- a/src/database/Models/Utilisateurs_discord.ts
+++ b/src/database/Models/Utilisateurs_discord.ts
@@ -12,6 +12,7 @@ export interface UtilisateurDiscord {
     first_activity: string | null;
     last_activity: string | null;
     nb_message: number;
+    vocal_time: number;
     avatar_url: string;
 }
 
@@ -113,6 +114,36 @@ export class UtilisateursDiscord implements I_Utilisateurs_discord {
             console.error("❌ Erreur dans registerLastActivity :", error);
         }
     }
+
+    // Ajoute le temps de vocal de l'utilisateur
+
+    static async addVocalTime(discord_id: string, vocalTime: number): Promise<void> {
+        try {
+            // On force ici le typage du résultat de db.select
+            const actualVocalTime = await db.select(
+                UtilisateursDiscord.getTableName(),
+                { discord_id }
+            ) as DbSelectResult<UtilisateurDiscord>;
+
+            if (actualVocalTime.results.length > 0) {
+                const user = actualVocalTime.results[0];
+                const vocalTimeToAdd = vocalTime + (user.vocal_time ?? 0);
+
+                const updateData: Partial<UtilisateurDiscord> = {
+                    vocal_time: vocalTimeToAdd,
+                };
+
+                await db.update(
+                    UtilisateursDiscord.getTableName(),
+                    updateData,
+                    `discord_id = '${discord_id}'`
+                );
+            } else {return}
+        } catch (error) {
+            console.error("❌ Erreur dans registerLastActivity :", error);
+        }
+    }
+
 }
 
 export default UtilisateursDiscord

--- a/src/events/VoiceStateUpdate.ts
+++ b/src/events/VoiceStateUpdate.ts
@@ -1,0 +1,90 @@
+import {Client, Events, VoiceState} from "discord.js";
+import { errorLogs } from "../utils/message/logs/errorLogs";
+import Utilisateurs_discord from "../database/Models/Utilisateurs_discord";
+import {eventLogger} from "./logs/EventLogger";
+
+// Map pour stocker le temps cumulé en ms
+const voiceTimes: Map<string, number> = new Map();
+// Map pour stocker l'heure d'entrée dans le vocal
+const joinTimestamps: Map<string, number> = new Map();
+
+// Fonction pour sauvegarder dans la DB en heures décimales
+async function saveVoiceTime(userId: string, totalMs: number) {
+    try {
+        const hoursDecimal = totalMs / 1000 / 60 / 60; // conversion en heures décimales
+        await Utilisateurs_discord.addVocalTime(userId, hoursDecimal);
+        eventLogger(`[SAVE] Temps vocal de ${userId} sauvegardé : ${hoursDecimal.toFixed(2)}h`, "voiceStateUpdate");
+    } catch (error) {
+       eventLogger("Erreur saveVoiceTime: " + error, "voiceStateUpdate");
+    }
+}
+
+// Flush périodique toutes les 5 minutes
+setInterval(async () => {
+    try {
+        const now = Date.now();
+
+        for (const [userId, joinTime] of joinTimestamps.entries()) {
+            const elapsed = now - joinTime;
+            const total = (voiceTimes.get(userId) || 0) + elapsed;
+
+            await saveVoiceTime(userId, total);
+
+            // Mettre à jour les maps
+            joinTimestamps.set(userId, now);
+            voiceTimes.set(userId, total);
+
+            eventLogger(`[FLUSH] Mise à jour de l'utilisateur ${userId} : ${total}ms`, "voiceStateUpdate");
+        }
+
+    } catch (err) {
+        eventLogger("Erreur sur le flush périodique: " + err, "voiceStateUpdate")
+    }
+}, 5 * 60 * 1000);
+
+export default {
+    name: Events.VoiceStateUpdate,
+    async execute(oldState: VoiceState, newState: VoiceState, client: Client) {
+        const userId = newState.id;
+
+        try {
+            // Entrée dans un canal vocal
+            if (!oldState.channel && newState.channel) {
+                joinTimestamps.set(userId, Date.now());
+                eventLogger(`[JOIN] ${userId} a rejoint le canal vocal ${newState.channel.id}`, "voiceStateUpdate");
+            }
+
+            // Sortie d’un canal vocal
+            if (oldState.channel && !newState.channel) {
+                const joinTime = joinTimestamps.get(userId);
+                if (joinTime) {
+                    const elapsed = Date.now() - joinTime;
+                    voiceTimes.set(userId, (voiceTimes.get(userId) || 0) + elapsed);
+                    joinTimestamps.delete(userId);
+
+                    eventLogger(`[LEAVE] ${userId} a quitté le canal vocal ${oldState.channel.id}, temps passé: ${elapsed}ms`, "voiceStateUpdate");
+
+                    // Sauvegarde immédiate en heures décimales
+                    await saveVoiceTime(userId, voiceTimes.get(userId)!);
+                }
+            }
+
+            // Changement de canal vocal
+            if (
+                oldState.channel &&
+                newState.channel &&
+                oldState.channel.id !== newState.channel.id
+            ) {
+                const joinTime = joinTimestamps.get(userId);
+                if (joinTime) {
+                    const elapsed = Date.now() - joinTime;
+                    voiceTimes.set(userId, (voiceTimes.get(userId) || 0) + elapsed);
+                    eventLogger(`[MOVE] ${userId} a changé de canal ${oldState.channel.id} -> ${newState.channel.id}, temps précédent: ${elapsed}ms`, "voiceStateUpdate");
+                }
+                joinTimestamps.set(userId, Date.now());
+            }
+        } catch (err) {
+            errorLogs(`Erreur VoiceStateUpdate pour ${userId}`, "", client);
+        }
+    },
+};

--- a/src/events/logs/EventLogger.ts
+++ b/src/events/logs/EventLogger.ts
@@ -1,0 +1,4 @@
+export function eventLogger(message: string, eventName: string) {
+    console.log(`[${eventName}] ${message}`)
+    // Todo : Implémenter la redirection des logs dans des fichiers
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ const client = new Client({
         GatewayIntentBits.GuildMessageReactions,
         GatewayIntentBits.MessageContent,
         GatewayIntentBits.GuildMembers,
+        GatewayIntentBits.GuildVoiceStates,
     ]
 })
 

--- a/src/task/badges/utilisateursBadges.ts
+++ b/src/task/badges/utilisateursBadges.ts
@@ -22,6 +22,7 @@ export type UserDataType = {
     first_activity: string;
     last_activity: string;
     nb_message: number;
+    vocal_time: number;
     tag_discord: string;
     avatar_url: string;
 };
@@ -34,6 +35,7 @@ export class UtilisateursBadges {
     firstActivity: string;
     lastActivity: string;
     nbMessage: number;
+    vocal_time: number;
     tag: string;
     avatarUrl: string;
 
@@ -45,6 +47,7 @@ export class UtilisateursBadges {
         this.firstActivity = user.first_activity;
         this.lastActivity = user.last_activity;
         this.nbMessage = user.nb_message;
+        this.vocal_time = user.vocal_time;
         this.tag = user.tag_discord;
         this.avatarUrl = user.avatar_url;
     }
@@ -99,7 +102,38 @@ export class UtilisateursBadges {
                     utilisateur_id: userData.id,
                     badge_id: 9, // badge 1000 messages
                     date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
-                }] : [])
+                }] : []),
+                // Badge pour avoir rejoint un vocal
+                ...(userData.vocal_time > 0 ? [{
+                    utilisateur_id: userData.id,
+                    badge_id: 15, // badge rejoint un vocal
+                    date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
+                }] : []),
+
+                // Badge pour être resté pendant 1h dans un vocal
+                ...(userData.vocal_time > 1 ? [{
+                    utilisateur_id: userData.id,
+                    badge_id: 16, // badge 1h
+                    date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
+                }] : []),
+                // Badge pour être resté pendant 10h dans un vocal
+                ...(userData.vocal_time > 10 ? [{
+                    utilisateur_id: userData.id,
+                    badge_id: 17, // badge 10h
+                    date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
+                }] : []),
+                // Badge pour être resté pendant 24h dans un vocal
+                ...(userData.vocal_time > 24 ? [{
+                    utilisateur_id: userData.id,
+                    badge_id: 18, // badge 24h
+                    date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
+                }] : []),
+                // Badge pour être resté pendant 100h dans un vocal
+                ...(userData.vocal_time > 100 ? [{
+                    utilisateur_id: userData.id,
+                    badge_id: 19, // badge 100h
+                    date_recu: new Date().toISOString().slice(0, 19).replace("T", " "),
+                }] : []),
             ];
 
 


### PR DESCRIPTION
- Suivi des temps passés en vocal par utilisateur via un nouvel événement `VoiceStateUpdate`.
- Enregistrement des temps vocaux en base de données (conversion en heures décimales).
- Attribution automatique de nouveaux badges basés sur la durée en vocal.
- Mise à jour des dossiers `utilisateursBadges`, `Models/Utilisateurs_discord` et création d'un logger pour les événements.
- Ajout de l'intention `GuildVoiceStates` pour la gestion des états vocaux.